### PR TITLE
fix(ui): dropdown re-selection always picks first task from today

### DIFF
--- a/src/renderer/src/components/Tasks.svelte
+++ b/src/renderer/src/components/Tasks.svelte
@@ -129,12 +129,19 @@
     }
     const taskDef = $taskDefinitions.find(td => td.id === taskDefId) || null
     selectedTaskDefinition.set(taskDef)
-    const existingTask = tasksList.find(
+    const tasksForToday = tasksList.filter(
       t =>
         t.taskDefinitionId === taskDefId &&
         t.date === new Date().toISOString().slice(0, 10),
     )
-    selectedTask.set(existingTask)
+    const activeTaskIds = new Set($activeTasks.map(at => at.taskId))
+    const activeTaskForDefinition = tasksForToday.find(t =>
+      activeTaskIds.has(t.id),
+    )
+    const latestTaskForDefinition =
+      tasksForToday.length > 0 ? tasksForToday[tasksForToday.length - 1] : null
+
+    selectedTask.set(activeTaskForDefinition || latestTaskForDefinition)
   }
 
   async function handleEditModalClose(editedTask: DBTask) {


### PR DESCRIPTION
The dropdown re-selection currently picks the
first task from today for that definition, not
necessarily the running one.

The dropdown selection logic now prefers the currently running task interval when re-selecting a task definition:

It gathers all today tasks for the selected task definition. Builds a set of active task IDs from $activeTasks. Picks the matching active task first.

Falls back to the latest task for today if none is active. So now, after starting a task, switching to another definition, and switching back, the Edit button targets the active running task (not an older one from today).